### PR TITLE
Add Patreon support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "att-voodoo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "att-voodoo",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "att-voodoo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A community-made magic mod for A Township Tale, a VR MMORPG game.",
   "main": "build/ui/main.js",
   "scripts": {

--- a/src/ui/atoms/index.ts
+++ b/src/ui/atoms/index.ts
@@ -6,6 +6,7 @@ export { experienceAtom, Experience, SpellUpgrades } from './experienceAtom';
 export { hasSessionAtom } from './hasSessionAtom';
 export { incantationsAtom, Incantation, StudyFeedback } from './incantationsAtom';
 export { panelAtom, Panel } from './panelAtom';
+export { patreonTierAtom } from './patreonTierAtom';
 export { preparedSpellsAtom, PreparedSpell } from './preparedSpellsAtom';
 export { serversAtom, Servers } from './serversAtom';
 export { speechModeAtom, SpeechMode } from './speechModeAtom';

--- a/src/ui/atoms/patreonTierAtom.ts
+++ b/src/ui/atoms/patreonTierAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const patreonTierAtom = atom<number>(0);

--- a/src/ui/components/Dashboard/Dashboard.tsx
+++ b/src/ui/components/Dashboard/Dashboard.tsx
@@ -19,7 +19,8 @@ import {
   Experience,
   spellbookAtom,
   studyingAtom,
-  dexterityAtom
+  dexterityAtom,
+  patreonTierAtom
 } from '@/atoms';
 import { ServersUpdate } from '@/components/ServersScreen';
 import { Dock } from '@/components/Dock';
@@ -39,11 +40,11 @@ const PREPARED_SPELLS_CONFIG = {
   constant: 0.0000343
 };
 
-const calcPreparedSpells = (xpTotal: number): number => {
+const calcPreparedSpells = (xpTotal: number, patreonTier: number): number => {
   const { min, max, constant } = PREPARED_SPELLS_CONFIG;
   const preparedSpells = max - (max - min) * Math.exp(-constant * xpTotal);
 
-  return Math.round(preparedSpells);
+  return Math.round(preparedSpells) + patreonTier * 5;
 };
 
 const VOLUME_EXPONENT = 3; /* Linear volume adjustments are evil! */
@@ -84,6 +85,7 @@ export const Dashboard = (): JSX.Element => {
   const [preparedSpells, setPreparedSpells] = useAtom(preparedSpellsAtom);
   const [experience, setExperience] = useAtom(experienceAtom);
   const [, setDexterity] = useAtom(dexterityAtom);
+  const [patreonTier, setPatreonTier] = useAtom(patreonTierAtom);
   const [spellbook] = useAtom(spellbookAtom);
   const [studying] = useAtom(studyingAtom);
   const [panel, setPanel] = useAtom(panelAtom);
@@ -225,6 +227,7 @@ export const Dashboard = (): JSX.Element => {
           setPreparedSpells(response.result.preparedSpells);
           setExperience(response.result.experience);
           setDexterity(response.result.dexterity.split('Hand/'));
+          setPatreonTier(response.result.patreonTier ?? 0);
         } else {
           console.error(response.error);
         }
@@ -259,7 +262,8 @@ export const Dashboard = (): JSX.Element => {
     handleVoodooConjureHeartfruit,
     setPreparedSpells,
     setExperience,
-    setDexterity
+    setDexterity,
+    setPatreonTier
   ]);
 
   useEffect(() => {
@@ -302,7 +306,7 @@ export const Dashboard = (): JSX.Element => {
         <div className={styles.spellsHeader}>
           Prepared Spells{' '}
           <span className={styles.spellSlots}>
-            {preparedSpells.length}/{calcPreparedSpells(xpTotal)}
+            {preparedSpells.length}/{calcPreparedSpells(xpTotal, patreonTier)}
           </span>
         </div>
         <div className={styles.spells}>

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -2,6 +2,6 @@
   "name": "att-voodoo",
   "description": "A community-made magic mod for A Township Tale, a VR MMORPG game.",
   "author": "Marc Dingena",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "main.js"
 }

--- a/src/ui/routes/RootRoute.tsx
+++ b/src/ui/routes/RootRoute.tsx
@@ -7,7 +7,7 @@ import { Dashboard } from '@/components/Dashboard';
 
 export const RootRoute = (): JSX.Element => {
   const [appStage] = useAtom(appStageAtom);
-  return <Dashboard />;
+
   switch (appStage) {
     case AppStage.Connected:
       return <Dashboard />;

--- a/src/ui/routes/RootRoute.tsx
+++ b/src/ui/routes/RootRoute.tsx
@@ -7,7 +7,7 @@ import { Dashboard } from '@/components/Dashboard';
 
 export const RootRoute = (): JSX.Element => {
   const [appStage] = useAtom(appStageAtom);
-
+  return <Dashboard />;
   switch (appStage) {
     case AppStage.Connected:
       return <Dashboard />;


### PR DESCRIPTION
## Context

Heroku is shutting down its free services in about 3 months. To cover costs for running Voodoo I'm launching a Patreon page where people can contribute to the project. In return, patrons receive some perks in-game.

This PR adds support for those perks.